### PR TITLE
Multiple versions and better proxy rules

### DIFF
--- a/Dockerfile-deb
+++ b/Dockerfile-deb
@@ -4,17 +4,22 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV GOPATH /opt/go
 
 RUN apt-get update -yqq
-RUN apt-get install -yqq software-properties-common curl git mercurial ruby-dev gcc make
-RUN add-apt-repository -y ppa:ethereum/ethereum && apt-get update && apt-get -y install golang
+RUN apt-get install -yqq software-properties-common curl git mercurial ruby-dev gcc make wget
 RUN gem install fpm
+RUN wget https://storage.googleapis.com/golang/go1.6.2.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf go1.6.2.linux-amd64.tar.gz
+
+ENV PATH /usr/local/go/bin:$PATH
 
 ADD . /opt/go/src/github.com/seomoz/roger-bamboo
 
 WORKDIR /opt/go/src/github.com/seomoz/roger-bamboo
-RUN go get github.com/tools/godep && \
+
+RUN go version && \
+    go get github.com/tools/godep && \
     go get -t github.com/smartystreets/goconvey && \
     cp -r Godeps/_workspace/src/* /opt/go/src/ && \
-    go build
+    /opt/go/bin/godep go build
 
 RUN mkdir -p /output
 VOLUME /output

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![bamboo-logo](https://cloud.githubusercontent.com/assets/37033/4110258/a8cc58bc-31ef-11e4-87c9-dd20bd2468c2.png)
 
-roger-bamboo is a service discovey and distributed load balancing
+roger-bamboo is a service discovery and distributed load balancing
 system for Roger, Moz's ClusterOS. It is based on
 [Bamboo](https://github.com/QubitProducts/bamboo). Roger-bamboo adds
 several features to Bamboo including, flexible TCP and HTTP port

--- a/config/haproxy_template.cfg
+++ b/config/haproxy_template.cfg
@@ -79,9 +79,9 @@ backend {{ $app.EscapedId }}-cluster{{ if $app.HealthCheckPath }}
         {{ if $app.Env.HTTP_PORT }} {{ range $page, $task := .Tasks }}
 	  {{ if $app.Env.ENABLE_SESSION_AFFINITY }}
 	  {{ $serverhash := getServerHash $app.EscapedId $task.Host $task.Port }}
-	server {{ $serverhash }} {{ $task.Host }}:{{ $task.Port }} check cookie {{ $serverhash }}
+	server {{ $serverhash }} {{ $task.Host }}:{{ $task.Port }} check cookie {{ $serverhash }}{{ if $app.HealthCheckPath }} check{{ end }}
           {{ else }}
-        server {{ $app.EscapedId}}-{{ $task.Host }}-{{ getTaskPort $task.Ports $app.Env.HTTP_PORT }} {{ $task.Host }}:{{ getTaskPort $task.Ports $app.Env.HTTP_PORT }}
+        server {{ $app.EscapedId}}-{{ $task.Host }}-{{ getTaskPort $task.Ports $app.Env.HTTP_PORT }} {{ $task.Host }}:{{ getTaskPort $task.Ports $app.Env.HTTP_PORT }}{{ if $app.HealthCheckPath }} check{{ end }}
           {{ end }}
         {{ end }} {{ end }}
 # End Backend section for {{ $app.EscapedId }} {{ end }}

--- a/services/haproxy/haproxy.go
+++ b/services/haproxy/haproxy.go
@@ -11,12 +11,16 @@ import (
 type TemplateData struct {
 	Apps     marathon.AppList
 	Services map[string]service.Service
+	Acls map[string]bool
+	BackendRules map[string]string
 }
 
 func GetTemplateData(config *conf.Configuration, conn *zk.Conn) TemplateData {
 
 	apps, _ := marathon.FetchApps(config.Marathon)
 	services, _ := service.All(conn, config.Bamboo.Zookeeper)
+	acls := make(map[string]bool)
+	backendrules := make(map[string]string)
 
-	return TemplateData{apps, services}
+	return TemplateData{apps, services, acls, backendrules}
 }

--- a/services/template/template.go
+++ b/services/template/template.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"text/template"
 	"time"
+	"strings"
+	"sort"
 )
 
 // The set of regexes defining valid port descriptions. a valid
@@ -76,11 +78,49 @@ func getServerHash(escapeId string, host string, port int) string {
 	return fmt.Sprintf("%X", hash)
 }
 
+/* Compute a hash for the given 2 strings */
+func getVersionHash(appId string, version string) string {
+	hasher.Write([]byte(appId))
+	hasher.Write([]byte(version))
+	hash := hasher.Sum32()
+	hasher.Reset()
+	return fmt.Sprintf("%X", hash)
+}
+
+/* Replaces "/" with "::" */
+func escapeSlashes(someString string) string {
+	return strings.Replace(someString, "/", "::", -1)
+}
+
+/* Adds the acl into the acls set */
+func addAcl(acls map[string]bool, acl string) string {
+	acls[acl] = true
+	return ""
+}
+
+/* Adds (updates) the backed rule (as value) for the given condition (as key) into the backend rule map */
+func addBackendRule(backendrules map[string]string, backend string, condition string) string {
+	backendrules[condition] = backend
+	return ""
+}
+
+/* Returns the conditions (keys) in descending order from backendrules map */
+func getConditionsDescending(backendrules map[string]string) []string {
+	conditions := make([]string, len(backendrules))
+	i := 0
+	for k := range backendrules {
+		conditions[i] = k
+		i++
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(conditions)))
+	return conditions
+}
+
 /*
 	Returns string content of a rendered template
 */
 func RenderTemplate(templateName string, templateContent string, data interface{}) (string, error) {
-	funcMap := template.FuncMap{"hasKey": hasKey, "getService": getService, "getTime": getTime, "getTaskPort": getTaskPort, "getServerHash": getServerHash}
+	funcMap := template.FuncMap{"hasKey": hasKey, "getService": getService, "getTime": getTime, "getTaskPort": getTaskPort, "getServerHash": getServerHash, "getVersionHash": getVersionHash, "escapeSlashes": escapeSlashes, "addAcl": addAcl, "addBackendRule": addBackendRule, "getConditionsDescending": getConditionsDescending }
 
 	tpl := template.Must(template.New(templateName).Funcs(funcMap).Parse(templateContent))
 

--- a/services/template/template.go
+++ b/services/template/template.go
@@ -19,6 +19,7 @@ import (
 var taskPortRegex = regexp.MustCompile("^PORT([\\d]+)$")
 var numPortRegex = regexp.MustCompile("^[\\d]+$")
 var hasher = fnv.New32a()
+var hasher64 = fnv.New64a()
 
 func hasKey(data map[string]service.Service, appId string) bool {
 	_, exists := data[appId]
@@ -78,12 +79,11 @@ func getServerHash(escapeId string, host string, port int) string {
 	return fmt.Sprintf("%X", hash)
 }
 
-/* Compute a hash for the given 2 strings */
-func getVersionHash(appId string, version string) string {
-	hasher.Write([]byte(appId))
-	hasher.Write([]byte(version))
-	hash := hasher.Sum32()
-	hasher.Reset()
+/* Compute a hash for the given string */
+func getHash(str string) string {
+	hasher64.Write([]byte(str))
+	hash := hasher64.Sum64()
+	hasher64.Reset()
 	return fmt.Sprintf("%X", hash)
 }
 
@@ -120,7 +120,7 @@ func getConditionsDescending(backendrules map[string]string) []string {
 	Returns string content of a rendered template
 */
 func RenderTemplate(templateName string, templateContent string, data interface{}) (string, error) {
-	funcMap := template.FuncMap{"hasKey": hasKey, "getService": getService, "getTime": getTime, "getTaskPort": getTaskPort, "getServerHash": getServerHash, "getVersionHash": getVersionHash, "escapeSlashes": escapeSlashes, "addAcl": addAcl, "addBackendRule": addBackendRule, "getConditionsDescending": getConditionsDescending }
+	funcMap := template.FuncMap{"hasKey": hasKey, "getService": getService, "getTime": getTime, "getTaskPort": getTaskPort, "getServerHash": getServerHash, "getHash": getHash, "escapeSlashes": escapeSlashes, "addAcl": addAcl, "addBackendRule": addBackendRule, "getConditionsDescending": getConditionsDescending }
 
 	tpl := template.Must(template.New(templateName).Funcs(funcMap).Parse(templateContent))
 


### PR DESCRIPTION
* Switched to go 1.6.2 to fix the odd intermittent haproxy 503s that were because of a bug in go 1.5 wherein exec would sometimes create processes with blocked signals - golang/go#13164. The old binary was built with 1.4 and didn’t have this problem.
* ROGER-985 - [LB] Update LB to support multiple versions of an http app (with version affinity)
* ROGER-984 - [LB] Update LB to better support HTTP_PREFIX substrings
* Support for ROGER-984 & ROGER-985:
  * Allows the ability to store and prioritize haproxy acls and backend rules to better handle them.
  * Examples:
     * Provide the ability to differentiate between `/path1` and `/path1/path2` irrespective of order of deployment because in descending oder `/path1/path2` will come before `/path1` (if `/path1` ends up first, requests for `/path1/path2` also goes to `/path1` which is undesirable.
     * Provide the ability to deploy multiple apps (say different versions) on the same path (acl) and make it possible to have the last deploy take precedence over older ones for new clients (if required, session affinity and version affinity can allow existing clients to still talk to older ones.)

Goes with - https://github.com/seomoz/roger-mesos/pull/57