### PR TITLE
Configure polling and marathon event callback

### DIFF
--- a/config/dev-cluster.json
+++ b/config/dev-cluster.json
@@ -1,10 +1,12 @@
 {
   "Marathon": {
-    "Endpoint": "http://machine01:8080,http://machine02:8080,http://machine03:8080"
+    "Endpoint": "http://machine01:8080,http://machine02:8080,http://machine03:8080",
+    "PollingInterval": 30
   },
 
   "Bamboo": {
     "Endpoint": "http://localhost:8000",
+    "RegisterCallback": true,
     "Zookeeper": {
       "Host": "machine01,machine02,machine03",
       "Path": "/bamboo/state",

--- a/config/development.json
+++ b/config/development.json
@@ -1,10 +1,12 @@
 {
   "Marathon": {
-    "Endpoint": "http://localhost:8080"
+    "Endpoint": "http://localhost:8080",
+    "PollingInterval": 30
   },
 
   "Bamboo": {
     "Endpoint": "http://10.0.2.2:8000",
+    "RegisterCallback": true,
     "Zookeeper": {
       "Host": "localhost",
       "Path": "/foo",

--- a/config/production.example.json
+++ b/config/production.example.json
@@ -1,10 +1,12 @@
 {
   "Marathon": {
-    "Endpoint": "http://marathon1:8080,http://marathon2:8080,http://marathon3:8080"
+    "Endpoint": "http://marathon1:8080,http://marathon2:8080,http://marathon3:8080",
+    "PollingInterval": 30
   },
 
   "Bamboo": {
     "Endpoint": "http://haproxy-ip-address:8000",
+    "RegisterCallback": true,
     "Zookeeper": {
       "Host": "localhost",
       "Path": "/marathon-haproxy/state",

--- a/configuration/Bamboo.go
+++ b/configuration/Bamboo.go
@@ -4,6 +4,10 @@ type Bamboo struct {
 	// Service host
 	Endpoint string
 
+	// enables or disabled the registering of the Marathon event callback
+	// the callback is used any time there are application changes within Marathon
+	RegisterCallback bool
+
 	// Routing configuration storage
 	Zookeeper Zookeeper
 }

--- a/configuration/marathon.go
+++ b/configuration/marathon.go
@@ -10,6 +10,10 @@ import (
 type Marathon struct {
 	// comma separated marathon http endpoints including port number
 	Endpoint string
+
+	// this controls how often bamboo polls marathon for new applications
+	// (unit is seconds, minimum is 1 second, default is 30 seconds)
+	PollingInterval int
 }
 
 func (m Marathon) Endpoints() []string {

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -125,7 +125,11 @@ func initServer(conf *configuration.Configuration, conn *zk.Conn, eventBus *even
 	goji.Get("/*", http.FileServer(http.Dir(path.Join(executableFolder(), "webapp"))))
 
 	log.Println("in initServer 4")
-	registerMarathonEvent(conf)
+	if conf.Bamboo.RegisterCallback {
+		registerMarathonEvent(conf)
+	} else {
+		log.Println("Skip registering the Bamboo callback with Marathon")
+	}
 
 	goji.Serve()
 }

--- a/main/bamboo/bamboo.go
+++ b/main/bamboo/bamboo.go
@@ -73,7 +73,11 @@ func main() {
 	log.Println("Registered handlers")
 
 	// Start periodic config updates
-	ticker := time.Tick(30 * time.Second)
+	if conf.Marathon.PollingInterval < 1 {
+		log.Println("Marathon.PollingInterval must be at least 1 second, resetting to 30 second default")
+		conf.Marathon.PollingInterval = 30
+	}
+	ticker := time.Tick(time.Duration(conf.Marathon.PollingInterval) * time.Second)
 	go func() {
 		for {
 			<-ticker


### PR DESCRIPTION
These two changes are meant to make it easier to use Bamboo along with Envoy, and to prevent Bamboo from rapid reloading Envoy which causes it to crash.

The build works:
```
> docker build -t bamboo-build -f Dockerfile-deb .
.....
Successfully built e689988894b2
Successfully tagged bamboo-build:latest
```

```
> docker run --rm -v $(pwd)/output:/output -e "_BAMBOO_VERSION=1.3.4" bamboo-build
/opt/go/src/github.com/seomoz/roger-bamboo/builder/build /opt/go/src/github.com/seomoz/roger-bamboo/builder
/opt/go/src/github.com/seomoz/roger-bamboo/builder/build/bamboo /opt/go/src/github.com/seomoz/roger-bamboo/builder/build /opt/go/src/github.com/seomoz/roger-bamboo/builder
{:timestamp=>"2019-03-19T18:21:10.151603+0000", :message=>"Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag", :level=>:warn}
{:timestamp=>"2019-03-19T18:21:10.623400+0000", :message=>"Created package", :path=>"bamboo_1.3.4-1_all.deb"}
/opt/go/src/github.com/seomoz/roger-bamboo/builder/build /opt/go/src/github.com/seomoz/roger-bamboo/builder
> ls output/
bamboo_1.3.4-1_all.deb
```